### PR TITLE
Add support to cache gists from the network

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,9 @@
  */
 var request = require('request');
 var Q       = require('q');
+var crypto  = require('crypto');
+var fs      = require('fs');
+var path    = require('path');
 
 /**
 * Gist prototype.
@@ -49,10 +52,12 @@ function Gist( options, files ) {
   this.posts = [];
   this.warnings = [];
   this.options = {
-    debug: options.debug || false
+    debug: options.debug || false,
+    caching: options.caching !== false, // null, undefined default to true
+    cacheDir: options.cacheDir || ".gists"
   };
 
-};
+}
 
 app.init = function( callback ) {
 
@@ -129,6 +134,12 @@ app.eachPost = function( file, callback ) {
 
 app.getGist = function( gist ) {
 
+  var cachedGist = this.options.caching && this.getCachedData( gist );
+  if (cachedGist) {
+    return Q({ gist: gist, res: cachedGist });
+  }
+
+  var that = this;
   var deferred = Q.defer();
   var url = this.helpers.githubUrl( gist );
 
@@ -139,6 +150,7 @@ app.getGist = function( gist ) {
       if ( response.statusCode !== 200 ) {
         throw { statusCode: response.statusCode };
       }
+      that.writeCachedData( gist, body );
       var res = JSON.parse(body);
       return { gist: gist, res: res };
     })
@@ -171,6 +183,34 @@ app.showWarnings = function() {
 
 };
 
+app.getCachedData = function( gist ) {
+  var cacheName = path.resolve( path.join( './', this.cacheName( gist ) ) );
+
+  if ( fs.existsSync( cacheName ) ) {
+    return require( cacheName );
+  } else {
+    return null;
+  }
+
+};
+
+app.writeCachedData = function( gist, body ) {
+
+  var cacheName = this.cacheName( gist );
+  this.helpers.makeCacheDir( this.options.cacheDir );
+  fs.writeFileSync( cacheName, body );
+
+};
+
+app.cacheName = function( gist ) {
+
+  var md5sum = crypto.createHash( 'md5' );
+  md5sum.update( gist.fullName );
+  var name = md5sum.digest( 'hex' );
+  return path.join( this.options.cacheDir, name + '.json' );
+
+};
+
 
 /**
 * Helpers
@@ -200,6 +240,12 @@ app.helpers = {
     var s = '<link rel="stylesheet" href="' + ghGist.stylesheet + '">',
         d = ghGist.div.replace(/(\r\n|\n|\r)/gm,"");
     return s + d;
+  },
+
+  makeCacheDir: function( directory ) {
+    if ( !fs.existsSync( directory ) ) {
+      fs.mkdir( directory );
+    }
   }
 
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,6 +165,8 @@ app.showWarnings = function() {
     this.warnings.forEach( function( w ) {
       console.log( "metalsmith-gist: " + w );
     });
+  } else if ( this.warnings.length ) {
+    console.log( "Warnings suppressed. Set debug:true to see warnings." );
   }
 
 };


### PR DESCRIPTION
With a fresh run on my [website](http://tritarget.org/) the two bottle necks to building were the gist plugin and the templates plugin. Realizing the real slow down in the gist plugin was the many network requests needed (one per gist in the blog).

This patch add caching by saving the response JSON from the server into a `.gists/` folder. It uses MD5 to sanitize the filename (since a gist has slashs and other non-filename characters in it).

This can be turned off with the `caching: false` option.
## Benchmarks
- Initial run (no cache):  **1359ms**
- Second run (with cache): **9ms**

Obviously the caveats are:
1. The user needs to put the cache directory in their `.gitignore`. The directory can be set via the `cacheDir` option that defauts to `.gists`.
2. If the gists are updated on github then the cache needs to be cleared to get the update. `rm -rf .gists/`
